### PR TITLE
Implement option to not require a brand account login to generate auto-import

### DIFF
--- a/launchers/bin/msu.py
+++ b/launchers/bin/msu.py
@@ -89,11 +89,20 @@ Create and sign a System-User Assertion using a local snapcraft key that has bee
     required.add_argument('-k', '--key', required=True,
         help=('The name of the snapcraft key to use to sign the system user assertion. The key must exist locally and be reported by "snapcraft keys". The key must also be registered.')
         )
-    parser.add_argument('--no-login',
+    # Only show these options if user has explictly said they want to see these options. You should
+    # know what you are doing before using them
+    parser.add_argument('--unsupported',
         default=False,
         action="store_true",
-        help=('Does not require user to provide brand account credentials. Uses Brand ID and local key signature with no verification.')
+        help=('Allow using dangerous and unsupported options. You should know what you are doing before using them.')
         )
+    if "--unsupported" in sys.argv:
+        parser.add_argument('--no-login',
+            default=False,
+            action="store_true",
+            help=('Does not require user to provide brand account credentials. Uses Brand ID and local key signature with no verification. The key should be registered to the brand account otherwise bad things will happen. Use --unsupported option to use.')
+            )
+
     args = parser.parse_args()
     return args
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: make-system-user
-version: '12'
+version: '14'
 summary: Make a system user file for auto import
 description: Make an auto-import.assert file
   containing required assertions to create a system user

--- a/src/setup.py
+++ b/src/setup.py
@@ -19,7 +19,7 @@ from os import path
 
 setup(
     name='make-system-user',
-    version='12',
+    version='14',
     description='make-system-user creates system user assertion files for Ubuntu Core',
     packages=["http_clients"],
     project_urls={


### PR DESCRIPTION
As our organization was looking at what credentials/secrets we would need to expose to generate a system user, we noticed that the stock `make-system-user` needed both the signing key imported locally as well as have the brand account email/password. Ideally, we want to minimize access to the brand account because it has highly-privileged access to the Brand Store. We only want to provide access to the system-user signing private key and passphrase.

With this pull request, we have added an option to allow generating an auto-import.assert without  needing the brand store SSO account.
* The `brand_id` comes from the required `brand` option on the command line; with login, it comes from the `account_id` of the signed-in account.
* The `sign-key-sha3-384` comes from the SHA3-384 hash of the public part of the key name provided; it comes from the registered key part of the account information of the signed-in account.

One thing that logging in with brand account provides is that it verifies that the brand is correct and the given key is in fact registered to the brand account. In the no-login case, we don't get the verification but then, if that information is not valid, the generating `auto-import.assert` will not work on a brand device so no harm.

Sorry for the end-of-line whitespace trimming - hopefully it isn't important. I have it set by default on my editor to keep things clean. 