### PR TITLE
Build with core22 base to support Ubuntu LTS 22.04

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: Make an auto-import.assert file
 
 grade: stable
 confinement: classic
-base: core20
+base: core22
 
 apps:
     make-system-user:


### PR DESCRIPTION
make-system-user snap leverages the existing python version installed in the system due to the classic confinement. While running make-system-user application with Ubuntu 22.04, the developers ends up with having a broken link to python version 3.8 since the default Python version is 3.10 with Ubuntu 22.04. Therefore, the make-system-user snap needs to be built with core22 base so that it is compatible with Ubuntu 22.04 