### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # make-system-user
+
+
+**NOTICE**: As of March 31, 2024, `make-system-user` is deprecated. To create system-user assertions, please use the `snap sign --chain` feature in [snapd](https://github.com/snapcore/snapd). More information on this feature can be found in the [Ubuntu Core documentation](https://ubuntu.com/core/docs/system-user). Please see [this forum post](https://forum.snapcraft.io/t/make-system-user-deprecation/39044) for more info about the deprecation.

--- a/launchers/bin/launch.sh
+++ b/launchers/bin/launch.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
+
+echo "NOTICE: As of March 31, 2024, make-system-user is officially deprecated. Please see https://forum.snapcraft.io/t/make-system-user-deprecation/39044 for more info." 1>&2
+
 $SNAP/bin/python3 $SNAP/bin/msu.py "$@"


### PR DESCRIPTION
Add a deprecation notice to the README.

Note: this PR does not in and of itself serve as an official deprecation notice, and the timeframe on which make-system-user will be deprecated is subject to change.